### PR TITLE
database-worker(api): Implemented "api/playground" GET method

### DIFF
--- a/backend/database/src/index.ts
+++ b/backend/database/src/index.ts
@@ -191,6 +191,22 @@ export default {
 				return new Response(pg.id, { status: 200})
 
 			}
+			else if (method == "GET"){
+				const params = url.searchParams
+				// if the request has an id, GET the playgrounds associated with it
+				// otherwise return ALL playgrounds :)
+				if (params.has("id")){
+					const id = params.get("id") as string
+					const res = await db.query.playground.findFirst({
+						where: (sandbox, { eq }) => eq(sandbox.id, id),
+					})
+					return json(res ?? {})
+				}
+				else {
+					const res = await db.select().from(playground).all()
+					return json(res ?? {})
+				}
+			}
 			else {
 				return methodNotAllowed
 			}


### PR DESCRIPTION
This PR adds a new `GET` method to the previous implemented `api/playground` endpoint (#24). The frontend may use this endpoint for two purposes:
1. Get all the playgrounds a user created 
2. Get all the playgrounds ever created. 