### PR TITLE
storage-worker(api): Implemented "api/project" endpoint DELETE method

### DIFF
--- a/backend/storage/src/index.ts
+++ b/backend/storage/src/index.ts
@@ -112,6 +112,27 @@ export default {
 
 			return success
 		}
+		else if (path === "/api/project" && method === "DELETE"){
+			const deleteSchema = z.object({
+				playgroundId: z.string(),
+			})
+
+			const body = await request.json()
+			const { playgroundId } = deleteSchema.parse(body)
+
+			const res = await env.R2.list({ prefix: "projects/" + playgroundId })
+
+			// delete all files related to the project
+			await Promise.all(
+				res.objects.map(
+					async (file) => {
+						await env.R2.delete(file.key)
+					}
+				)
+			)
+
+			return success
+		}
 		else {
 			return notFound
 		}


### PR DESCRIPTION
In this PR, I implement the `api/project` endpoint in the `Storage` worker. This endpoint is going to be used by the `Database` worker to manage projects (i.e. playgrounds) the user has created. In this case, the `Database` worker will send a `DELETE` request to this endpoint to delete all files related to a playground, effectively deleting the playground.